### PR TITLE
Add Jest test for chat route

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.53.0",
@@ -20,6 +21,9 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.5"
   }
 }

--- a/src/app/api/chat/route.test.ts
+++ b/src/app/api/chat/route.test.ts
@@ -1,0 +1,28 @@
+import { POST } from './route';
+import Anthropic from '@anthropic-ai/sdk';
+
+jest.mock('@anthropic-ai/sdk', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      messages: {
+        create: jest.fn().mockResolvedValue({
+          content: [{ text: 'Hello from Claude' }],
+        }),
+      },
+    })),
+  };
+});
+
+describe('POST /api/chat', () => {
+  it('returns assistant reply', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'Hi' }] }),
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+    expect(json.response).toBe('Hello from Claude');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest/ts-jest configuration
- create test verifying chat API response
- add test script and dev dependencies in `package.json`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e2b9ea60832bbe8822aa073199b9