### PR TITLE
Add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+ANTHROPIC_API_KEY=your-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ pnpm dev
 bun dev
 ```
 
+Before starting, copy `.env.example` to `.env` and add your Anthropic API key.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.


### PR DESCRIPTION
## Summary
- provide `.env.example` with Anthropic key placeholder
- allow `.env.example` in `.gitignore`
- document setup in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684587adcae8832bb97608d089e793af